### PR TITLE
fix: sqlfluff linting of dbt project

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -69,6 +69,18 @@ dbt_config = "{% macro config() %}{% for k in kwargs %}{% endfor %}{% endmacro %
 dbt_var = "{% macro var(variable, default='') %}item{% endmacro %}"
 dbt_is_incremental = "{% macro is_incremental() %}True{% endmacro %}"
 
+# Aliasing bundle (AL) configuration
+[tool.sqlfluff.rules.aliasing.expression]
+allow_scalar = false
+
+[tool.sqlfluff.rules.aliasing.length]
+min_alias_length = 4
+
+# Ambiguous bundle (AM) configuration
+[tool.sqlfluff.rules.ambiguous.column_references]
+group_by_and_order_by_style = "implicit"
+
+# Capitalisation bundle (CP) configuration
 [tool.sqlfluff.rules.capitalisation.keywords]
 capitalisation_policy = "lower"
 
@@ -81,21 +93,15 @@ capitalisation_policy = "lower"
 [tool.sqlfluff.rules.capitalisation.literals]
 capitalisation_policy = "lower"
 
-[tool.sqlfluff.rules.ambiguous.column_references]
-group_by_and_order_by_style = "implicit"
-
-[tool.sqlfluff.rules.aliasing.length]
-min_alias_length = 4
-
-[tool.sqlfluff.rules.aliasing.expression]
-allow_scalar = false
+[tool.sqlfluff.rules.capitalisation.types]
+capitalisation_policy = "lower"
 
 [tool.sqlfluff.rules.convention.not_equal]
 # Require != over <> for not equal
 preferred_not_equal_style = "c_style"
 
 [tool.sqlfluff.rules.convention.select_trailing_comma]
-select_clause_trailing_comma = "require"
+select_clause_trailing_comma = "forbid"
 
 # Included to be compatible with sqlfmt
 [tool.sqlfluff.rules.convention.terminator]


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Engineering Guide: TODO
     - 👷‍♀️ Create small PRs. In most cases this should be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use conventional commit messages: https://www.conventionalcommits.org/
     - 📗 Update any related documentation.
-->

## What type of PR is this? (check all applicable)

- [X] Fix
- [ ] Feature
- [ ] Other

## Does the PR contain a breaking change?

- [X] No
- [ ] Yes

## Description
A number of changes to SQLFluff config to resolve issues linting of dbt projects:
- adoption of SQLFluff v4.0.0 with Rust routines
- use `jinja` templater rather than `dbt` templater as a temporary work around
- update to SQLFluff config for trailing commas in select clause to reflect absence of support in Databricks SQL
- order rules per SQLFluff rule id

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Closes #79 
- Closes #80 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [X] No, and this is why: not relevant
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
No